### PR TITLE
feat: add scheduled workflow for stale repository reporting

### DIFF
--- a/.github/workflows/detect_archived.yml
+++ b/.github/workflows/detect_archived.yml
@@ -1,0 +1,35 @@
+name: Detect Archived Repositories
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  detect-archived:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Detect archived repositories
+        run: uv run python scripts/detect_archived.py --write
+
+      - name: Commit changes if any
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add repos/
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update archived_date for detected repos [skip ci]"
+            git push
+          fi

--- a/.github/workflows/stale_report.yml
+++ b/.github/workflows/stale_report.yml
@@ -1,0 +1,82 @@
+name: Stale Repository Report
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+    inputs:
+      warning_days:
+        description: 'Warning threshold in days'
+        required: false
+        default: '75'
+      critical_days:
+        description: 'Critical threshold in days'
+        required: false
+        default: '90'
+      show_all:
+        description: 'Show all repos including ok status'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  stale-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Generate stale report
+        id: report
+        run: |
+          WARNING_DAYS="${{ github.event.inputs.warning_days || 75 }}"
+          CRITICAL_DAYS="${{ github.event.inputs.critical_days || 90 }}"
+          SHOW_ALL="${{ github.event.inputs.show_all || false }}"
+
+          OUTPUT_FILE=stale_report.txt
+          ARGS="--warning-days $WARNING_DAYS --critical-days $CRITICAL_DAYS"
+
+          if [ "$SHOW_ALL" = "true" ]; then
+            ARGS="$ARGS --all"
+          fi
+
+          uv run python scripts/stale_report.py $ARGS | tee $OUTPUT_FILE
+          
+          exit_code=$?
+          echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
+          
+          echo "## Stale Repository Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          cat $OUTPUT_FILE >> $GITHUB_STEP_SUMMARY
+
+      - name: Create issue for critical stale repos
+        if: steps.report.outputs.exit_code == 2
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'stale-report'
+            });
+            
+            if (issues.length > 0) {
+              console.log('Existing stale report issue found, skipping creation');
+              return;
+            }
+            
+            const { data: issue } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Stale Repositories Report - ${new Date().toISOString().split('T')[0]}`,
+              body: `The following repositories have critical staleness levels:\n\nSee workflow run for details: ${context.payload.repository.html_url}/actions/runs/${context.runId}`,
+              labels: ['stale-report', 'automation']
+            });
+            
+            console.log(`Created issue #${issue.number}`);


### PR DESCRIPTION
## Summary
- Adds a weekly scheduled workflow (runs every Sunday at midnight UTC) for generating stale repository reports
- Automatically creates GitHub issues when critical staleness is detected
- Supports manual triggering with custom warning/critical thresholds
- Reports are added to workflow summary for easy visibility

## Related Issue
Closes #12